### PR TITLE
Add support for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "dist/index.js",
   "scripts": {
     "prebuild": "rm -rf dist && mkdir dist",
-    "build": "coffee -c -m -o dist src",
+    "build": "browserify -t coffeeify --extension='.coffee' src/index.coffee > dist/index.js",
     "commit": "git-cz",
     "check-coverage": "istanbul check-coverage --statements 90 --branches 90 --functions 95 --lines 90",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
-    "test": "mocha test/index.test.coffee -w --compilers coffee:coffee-script/register",
+    "test": "mocha test/index.test.coffee --compilers coffee:coffee-script/register",
     "test:single": "istanbul cover -x *.test.coffee _mocha -- test/index.test.coffee --compilers coffee:coffee-script/register --require coffee-coverage/register-istanbul",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "lint": "coffeelint src"
@@ -42,7 +42,9 @@
     "ghooks": "1.0.3",
     "istanbul": "0.4.1",
     "mocha": "2.3.4",
-    "semantic-release": "4.3.5"
+    "semantic-release": "4.3.5",
+    "browserify": "13.0.0",
+    "coffeeify": "2.0.1"
   },
   "config": {
     "commitizen": {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,5 +1,4 @@
 list = ["Michaela", "Sami", "Xavier"]
 
-module.exports = {
+module.exports =
   dev: list
-}

--- a/test/index.test.coffee
+++ b/test/index.test.coffee
@@ -1,6 +1,12 @@
 expect = require('chai').expect
-lib = require('../src/index')
+should = require('chai').should()
+
+lib = require '../src/index'
 
 describe 'dev', ->
   it 'should be an array of strings', ->
     expect(lib.dev).not.to.be.empty
+
+  describe 'lib.dev', ->
+    it 'should contain names', ->
+      lib.dev.should.include 'Xavier'


### PR DESCRIPTION
Adds support for browserify in the build (basically packages together coffee files that are required in the index.coffee or below). Couple of other smallish updates.
