### PR TITLE
fix(actions): Exclude duplicates from dataflow count

### DIFF
--- a/src/actions/cs-actions.coffee
+++ b/src/actions/cs-actions.coffee
@@ -53,7 +53,12 @@ fetchCS = (url) ->
           if artefact.class is 'CategoryScheme'
             artefact.categories = artefact.items
             for cat in artefact.categories
-              cat.dataflows = cat.children
+              cat.dataflows = []
+              usedIds = []
+              for flow in cat.children
+                if usedIds.indexOf(flow.id) is -1
+                  cat.dataflows.push flow
+                  usedIds.push flow.id
             schemes.push artefact
 
         dispatch csLoaded schemes)


### PR DESCRIPTION
Duplicates are not taken into account anymore when collecting the dataflows attached to a category

Closes #25
